### PR TITLE
[Engine/corejd 1902] support of Datetime64

### DIFF
--- a/lib/clickhouse/connection/query/result_set.rb
+++ b/lib/clickhouse/connection/query/result_set.rb
@@ -65,6 +65,8 @@ module Clickhouse
               parse_date_time_value value
             when /DateTime\(/
               parse_date_time_value(value, type.scan(/DateTime\('(.*)'\)/)&.first&.first)
+            when /DateTime64\(/
+              parse_date_time64_value(value, type.scan(/DateTime\((\d+,\s*)?'(.+)'\)/)&.first&.last)
             when /Array\(/
               parse_array_value value
             else
@@ -101,6 +103,11 @@ module Clickhouse
 
         def parse_date_time_value(value, tz=nil)
           return nil if value == '0000-00-00 00:00:00'
+          tz ? Time.parse(value + " " + tz) : Time.parse(value)
+        end
+
+        def parse_date_time64_value(value, tz=nil)
+          return nil if value.start_with? '1970-01-01 00:00:00'
           tz ? Time.parse(value + " " + tz) : Time.parse(value)
         end
 

--- a/lib/clickhouse/connection/query/result_set.rb
+++ b/lib/clickhouse/connection/query/result_set.rb
@@ -66,7 +66,7 @@ module Clickhouse
             when /DateTime\(/
               parse_date_time_value(value, type.scan(/DateTime\('(.*)'\)/)&.first&.first)
             when /DateTime64\(/
-              parse_date_time64_value(value, type.scan(/DateTime\((\d+,\s*)?'(.+)'\)/)&.first&.last)
+              parse_date_time64_value(value, type.scan(/DateTime64\(\d+,\s*'(.+)'\)/)&.first&.first)
             when /Array\(/
               parse_array_value value
             else

--- a/lib/clickhouse/connection/query/result_set.rb
+++ b/lib/clickhouse/connection/query/result_set.rb
@@ -66,7 +66,7 @@ module Clickhouse
             when /DateTime\(/
               parse_date_time_value(value, type.scan(/DateTime\('(.*)'\)/)&.first&.first)
             when /DateTime64\(/
-              parse_date_time64_value(value, type.scan(/DateTime64\(\d+,\s*'(.+)'\)/)&.first&.first)
+              parse_date_time_value(value, type.scan(/DateTime64\(\d+,\s*'(.+)'\)/)&.first&.first)
             when /Array\(/
               parse_array_value value
             else
@@ -102,12 +102,9 @@ module Clickhouse
         end
 
         def parse_date_time_value(value, tz=nil)
-          return nil if value == '0000-00-00 00:00:00'
-          tz ? Time.parse(value + " " + tz) : Time.parse(value)
-        end
-
-        def parse_date_time64_value(value, tz=nil)
           return nil if value.start_with? '1970-01-01 00:00:00'
+          return nil if tz && value.start_with?('1970-01-01') # datetime with tz starts from non-zero hour
+
           tz ? Time.parse(value + " " + tz) : Time.parse(value)
         end
 


### PR DESCRIPTION
Currently in workato code we don't use timestamp columns directly (I almost sure about it) and this is not a big issue, because we have requests like:
```sql
SELECT argMax(started_at_dt, event_ms_ts)
...
```
But code like this currently fails:
```ruby
result = Workato::Clickhouse::Storages.instance.default. \
  connection.query("SELECT* FROM jobs_user_id LIMIT 1")
result.first # NotImplementedError: Cannot parse value of type "DateTime64(3)" (NotImplementedError)
```

Datetime64 can have 2 syntax forms `DateTime64(precision, [timezone])` (see [docs](https://clickhouse.com/docs/sql-reference/data-types/datetime64))

